### PR TITLE
Remove Money Metals

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -640,13 +640,6 @@
          silver. Location: Darmstadt, Germany.
       </li>
       <li>
-         &#9989; <a href="https://www.moneymetals.com/">Money Metals Exchange</a> - Buy and sell gold, silver, platinum,
-         palladium,
-         rhodium and copper. Location: Idaho, USA. Processor: Coin Payments.
-         <i>(Note: company says they can also buy precious metals and send Monero to you for them)</i>
-
-      </li>
-      <li>
          <a href="https://www.suissegold.eu/">Suisse Gold</a> - Gold, silver, platinum, palladium, and rhodium.
          Location: United Kingdom.
       </li>


### PR DESCRIPTION
Money Metals only accepts available currencies through BitPay, which does not include XMR.