### PR TITLE
Add kycnot.me to Exchange Comparision

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1169,6 +1169,9 @@
       <li>
          <a href="https://orangefren.com/">OrangeFren</a>
       </li>
+      <li>
+         <a href="https://kycnot.me/">KYCnot.me</a>
+      </li>
 
    </ul>
 


### PR DESCRIPTION
I would like to add my site (https://kycnot.me) to the monerica directory. KYCNOT.me lists exchanges and services which (most) accept Monero, it also provides information about them.

PS: Keep monerica up, it is an awesome resource!